### PR TITLE
Avoid warning about unused parameter

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -17,8 +17,8 @@ printf "\nStorage account created.\n"
 
 # Create two functions in Azure
 printf "\nCreating function apps in Azure...\n"
-az functionapp create --resource-group $RESOURCE_GROUP --consumption-plan-location $LOCATION --name $PRODUCT_FUNCTION_NAME --storage-account $STORAGE_ACCOUNT_NAME --runtime dotnet --functions-version 2
-az functionapp create --resource-group $RESOURCE_GROUP --consumption-plan-location $LOCATION --name $ORDER_FUNCTION_NAME --storage-account $STORAGE_ACCOUNT_NAME --runtime dotnet --functions-version 2
+az functionapp create --resource-group $RESOURCE_GROUP --consumption-plan-location $LOCATION --name $PRODUCT_FUNCTION_NAME --storage-account $STORAGE_ACCOUNT_NAME --functions-version 2
+az functionapp create --resource-group $RESOURCE_GROUP --consumption-plan-location $LOCATION --name $ORDER_FUNCTION_NAME --storage-account $STORAGE_ACCOUNT_NAME --functions-version 2
 printf "\nFunction apps created.\n"
 
 # Building the zip files for the functions


### PR DESCRIPTION
Need to test in the module exercises, but this might avoid the current warning folks encounter.

![Screenshot of command line showing a runtime-version not supported error.](https://user-images.githubusercontent.com/713665/129415735-b738206e-1c4b-4c81-bfa6-2540652be9b2.png)

