### PR TITLE
Fix functions-version param value

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -18,8 +18,8 @@ printf "\nStorage account created.\n"
 
 # Create two functions in Azure
 printf "\nCreating function apps in Azure...\n"
-az functionapp create --resource-group $RESOURCE_GROUP --consumption-plan-location $LOCATION --name $PRODUCT_FUNCTION_NAME --storage-account $STORAGE_ACCOUNT_NAME --functions-version 2
-az functionapp create --resource-group $RESOURCE_GROUP --consumption-plan-location $LOCATION --name $ORDER_FUNCTION_NAME --storage-account $STORAGE_ACCOUNT_NAME --functions-version 2
+az functionapp create --resource-group $RESOURCE_GROUP --consumption-plan-location $LOCATION --name $PRODUCT_FUNCTION_NAME --storage-account $STORAGE_ACCOUNT_NAME --functions-version 3
+az functionapp create --resource-group $RESOURCE_GROUP --consumption-plan-location $LOCATION --name $ORDER_FUNCTION_NAME --storage-account $STORAGE_ACCOUNT_NAME --functions-version 3
 printf "\nFunction apps created.\n"
 
 # Building the zip files for the functions


### PR DESCRIPTION
I changed the --functions-version param value in the two calls to az functionapp create from 2 to 3.

The older value of 2 was causing these two calls to fail which led to 5 Customer Feedback bugs for this reason.

Note: I went with the current default value for this parameter which is "3", even though the value of "4" is also acceptable.